### PR TITLE
Beamblade & Spaceworld stuff

### DIFF
--- a/include/functions.h
+++ b/include/functions.h
@@ -1744,6 +1744,7 @@ s32 Math3D_XYInSphere(Sphere16* sphere, f32 x, f32 y);
 s32 Math3D_YZInSphere(Sphere16* sphere, f32 y, f32 z);
 void Math3D_DrawSphere(GlobalContext* globalCtx, Sphere16* sph);
 void Math3D_DrawCylinder(GlobalContext* globalCtx, Cylinder16* cyl);
+void Math3D_DrawCylinderImpl(GraphicsContext* gfxCtx, Gfx** gfxP, f32 x, f32 y, f32 z, s16 radius, s16 height);
 s16 Math_Atan2S(f32 x, f32 y);
 f32 Math_Atan2F(f32 x, f32 y);
 void Matrix_Init(GameState* gameState);

--- a/include/z64player.h
+++ b/include/z64player.h
@@ -381,6 +381,7 @@ typedef struct Player {
     /* 0x0A86 */ s8         unk_A86;
     /* 0x0A87 */ u8         unk_A87;
     /* 0x0A88 */ Vec3f      unk_A88; // previous body part 0 position
+                 u8         doBladebeam;
 } Player; // size = 0xA94
 
 #endif

--- a/include/z64player.h
+++ b/include/z64player.h
@@ -381,7 +381,7 @@ typedef struct Player {
     /* 0x0A86 */ s8         unk_A86;
     /* 0x0A87 */ u8         unk_A87;
     /* 0x0A88 */ Vec3f      unk_A88; // previous body part 0 position
-                 u8         doBladebeam;
+                 u8         doBeamblade;
 } Player; // size = 0xA94
 
 #endif

--- a/src/code/z_player_lib.c
+++ b/src/code/z_player_lib.c
@@ -23,10 +23,10 @@ s16 sBootData[PLAYER_BOOTS_MAX][17] = {
     { 200, 1000, 300, 800, 500, 400, 800, 400, 800, 550, -100, 600, 540, 750, 125, 400, 200 },
 };
 
-// Used to map action params to model groups
+// Used to map action params to model groups, added last entry for standalone shield
 u8 sActionModelGroups[] = {
-    3,  15, 10, 2,  2,  5,  10, 11, 6,  6, 6, 6, 6, 6, 6, 6, 9, 9, 7, 7, 8, 3, 3, 6, 3, 3, 3, 3, 12, 13, 14, 14, 14, 14,
-    14, 14, 14, 14, 14, 14, 14, 14, 14, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,  3,  3,  3,  3,
+    3,  15, 10, 2,  2,  5,  10, 11, 6,  6, 6, 6, 6, 6, 6, 6, 9, 9, 7, 7, 8, 3, 3, 3, 3, 3, 3, 3, 12, 13, 14, 14, 14, 14,
+    14, 14, 14, 14, 14, 14, 14, 3,  14, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,  3,  3,  3,  3,  16,
 };
 
 TextTriggerEntry sTextTriggers[] = {
@@ -38,10 +38,10 @@ TextTriggerEntry sTextTriggers[] = {
 
 // Used to map model groups to model types for [animation, left hand, right hand, sheath, waist]
 u8 gPlayerModelTypes[][5] = {
-    { 2, 0, 10, 16, 20 }, { 1, 2, 9, 19, 20 },  { 1, 2, 10, 17, 20 }, { 0, 0, 8, 18, 20 },
-    { 0, 0, 8, 18, 20 },  { 3, 4, 9, 19, 20 },  { 4, 1, 11, 18, 20 }, { 5, 0, 8, 18, 20 },
-    { 0, 6, 8, 18, 20 },  { 4, 0, 15, 18, 20 }, { 3, 1, 9, 18, 20 },  { 3, 5, 9, 18, 20 },
-    { 0, 0, 13, 18, 20 }, { 0, 0, 14, 18, 20 }, { 0, 7, 8, 18, 20 },  { 0, 2, 8, 19, 20 },
+    { 2, 0, 10, 16, 20 }, { 1, 2, 9, 19, 20 },  { 1, 2, 10, 17, 20 }, { 0, 0, 8, 18, 20 },  
+    { 0, 0, 8, 18, 20 },  { 3, 4, 9, 19, 20 },  { 4, 1, 11, 18, 20 }, { 5, 0, 8, 18, 20 },  
+    { 0, 6, 8, 18, 20 },  { 4, 0, 15, 18, 20 }, { 3, 1, 9, 18, 20 },  { 3, 5, 9, 18, 20 },  
+    { 0, 0, 13, 18, 20 }, { 0, 0, 14, 18, 20 }, { 0, 7, 8, 18, 20 },  { 0, 2, 8, 19, 20 },  { 2, 0, 10, 16, 20 },
 };
 
 Gfx* D_80125CE8[] = {
@@ -327,6 +327,7 @@ s32 Player_ActionToModelGroup(Player* this, s32 actionParam) {
     }
 }
 
+// added for standalone shield
 void Player_SetModelsForHoldingShield(Player* this) {
     if ((this->stateFlags1 & 0x400000) &&
         ((this->itemActionParam < 0) || (this->itemActionParam == this->heldItemActionParam))) {
@@ -340,7 +341,18 @@ void Player_SetModelsForHoldingShield(Player* this) {
             }
             this->sheathDLists = &sPlayerDListGroups[this->sheathType][(void)0, gSaveContext.linkAge];
             this->modelAnimType = 2;
-            this->itemActionParam = -1;
+
+            // changed to make shield stay out after using it
+            if (this->heldItemActionParam == PLAYER_AP_SWORD_KOKIRI ||
+                this->heldItemActionParam == PLAYER_AP_SWORD_MASTER ||
+                this->heldItemActionParam == PLAYER_AP_SWORD_BGS ||
+                this->heldItemActionParam == PLAYER_AP_SHIELD) {
+                this->itemActionParam = -1;
+            } else {
+                this->heldItemActionParam = this->itemActionParam = PLAYER_AP_SHIELD;
+                this->heldItemId = ITEM_SHIELD_DEKU;
+                this->modelGroup = this->nextModelGroup = Player_ActionToModelGroup(this, PLAYER_AP_SHIELD);
+            }
         }
     }
 }

--- a/src/overlays/actors/ovl_En_M_Thunder/z_en_m_thunder.c
+++ b/src/overlays/actors/ovl_En_M_Thunder/z_en_m_thunder.c
@@ -73,8 +73,8 @@ void EnMThunder_Init(Actor* thisx, GlobalContext* globalCtx2) {
                               this->actor.world.pos.z, 255, 255, 255, 0);
     this->lightNode = LightContext_InsertLight(globalCtx, &globalCtx->lightCtx, &this->lightInfo);
     this->collider.dim.radius = 0;
-    this->collider.dim.height = 40;
-    this->collider.dim.yShift = -20;
+    this->collider.dim.height = 50;
+    this->collider.dim.yShift = -30;
     this->unk_1C4 = 8;
     this->unk_1B4 = 0.0f;
     this->actor.world.pos = player->bodyPartsPos[0];
@@ -356,8 +356,8 @@ void EnMThunder_Beamblade(EnMThunder* this, GlobalContext* globalCtx) {
         Collider_UpdateCylinder(&this->actor, &this->collider);
         CollisionCheck_SetAT(globalCtx, &globalCtx->colChkCtx, &this->collider.base);
         this->collider.dim.radius = (this->actor.scale.x * 6.0f);
-        this->collider.dim.pos.x += ((Math_CosS(this->actor.prevPos.x) * - 50.0f) * (Math_SinS(this->actor.shape.rot.y)));
-        this->collider.dim.pos.z += ((Math_CosS(this->actor.prevPos.x) * - 50.0f) * (Math_CosS(this->actor.shape.rot.y)));
+        this->collider.dim.pos.x += ((Math_CosS(this->actor.prevPos.x) + - 50.0f) * (Math_SinS(this->actor.shape.rot.y)));
+        this->collider.dim.pos.z += ((Math_CosS(this->actor.prevPos.x) + - 50.0f) * (Math_CosS(this->actor.shape.rot.y)));
     }
 
     if (this->unk_1C4 > 0) { // unk_1C4 = timer

--- a/src/overlays/actors/ovl_En_M_Thunder/z_en_m_thunder.c
+++ b/src/overlays/actors/ovl_En_M_Thunder/z_en_m_thunder.c
@@ -11,7 +11,8 @@ void EnMThunder_Draw(Actor* thisx, GlobalContext* globalCtx);
 void func_80A9F314(GlobalContext* globalCtx, f32 arg1);
 void func_80A9F408(EnMThunder* this, GlobalContext* globalCtx);
 void func_80A9F9B4(EnMThunder* this, GlobalContext* globalCtx);
-void func_bladebeam(EnMThunder* this, GlobalContext* globalCtx);
+void EnMThunder_Beamblade(EnMThunder* this, GlobalContext* globalCtx);
+void EnMThunder_SetupBeamblade(EnMThunder* this, GlobalContext* globalCtx);
 
 const ActorInit En_M_Thunder_InitVars = {
     ACTOR_EN_M_THUNDER,
@@ -195,28 +196,29 @@ void func_80A9F408(EnMThunder* this, GlobalContext* globalCtx) {
             if ((this->actor.params & 0xFF00) >> 8) {
                 gSaveContext.unk_13F0 = 1;
             }
-            if (player->doBladebeam == 1) { // player is z-targeting and moving forward, do bladebeam
-                    if (player->unk_858 < 0.85f) { // blue bladebeam
+            if (player->doBladebeam == 1) { // player is z-targeting and moving forward, do beamblade
+                if (player->unk_858 < 0.85f) { // blue beamblade
                     this->collider.info.toucher.dmgFlags = D_80AA044C[this->unk_1C7]; // sets damage flags
-                    } else { // red bladebeam
-                        this->collider.info.toucher.dmgFlags = D_80AA0458[this->unk_1C7]; // sets damage flags
-                    }
-                    this->unk_1C6 = 2; // sets case for bladebeam displaylist
-                    func_80A9EFE0(this, func_bladebeam);
+                } else { // red beamblade
+                    this->collider.info.toucher.dmgFlags = D_80AA0458[this->unk_1C7]; // sets damage flags
+                }
+                this->unk_1C6 = 2; // sets case for beamblade displaylist
+                // func_80A9EFE0(this, EnMThunder_Beamblade);
+                EnMThunder_SetupBeamblade(this, globalCtx);
             } else {
                 if (player->unk_858 < 0.85f) { // blue spin attack
                     this->collider.info.toucher.dmgFlags = D_80AA044C[this->unk_1C7];
                     this->unk_1C6 = 1;
-                    this->unk_1C9 = ((this->unk_1C7 == 1) ? 2 : 4);
+                    this->unk_1C9 = ((this->unk_1C7 == 1) ? 2 : 4); // sets the actor scaling
                 } else { // red spin attack
                     this->collider.info.toucher.dmgFlags = D_80AA0458[this->unk_1C7];
                     this->unk_1C6 = 0;
-                    this->unk_1C9 = ((this->unk_1C7 == 1) ? 4 : 8);
+                    this->unk_1C9 = ((this->unk_1C7 == 1) ? 4 : 8); // sets the actor scaling
                 }
                 func_80A9EFE0(this, func_80A9F9B4);
             }
 
-            this->unk_1C4 = 8;
+            this->unk_1C4 = 8; // charge effect timer after release
             Audio_PlaySoundGeneral(sSfxIds[this->unk_1C6], &player->actor.projectedPos, 4, &D_801333E0, &D_801333E0,
                                    &D_801333E8);
             this->unk_1AC = 1.0f;
@@ -265,7 +267,7 @@ void func_80A9F938(EnMThunder* this, GlobalContext* globalCtx) {
     u8 fadecharge;
 
     if (this->unk_1C6 == 2) {
-        fadecharge = 6; // bladebeam, starts to fade earlier
+        fadecharge = 6; // beamblade, starts to fade earlier
     } else {
         fadecharge = 2; // spin attacks, starts to fade later
     }
@@ -320,17 +322,36 @@ void func_80A9F9B4(EnMThunder* this, GlobalContext* globalCtx) {
     }
 }
 
-void func_bladebeam(EnMThunder* this, GlobalContext* globalCtx) {
+void EnMThunder_SetupBeamblade(EnMThunder* this, GlobalContext* globalCtx) {
+    Player* player = GET_PLAYER(globalCtx);
+    s16 pitchTarget;
+    Actor* targetedActor;
+
+    targetedActor = player->unk_664; // sets the actor targeted by player to "target"
+    
+    if (targetedActor != NULL) {
+        pitchTarget = Actor_WorldPitchTowardPoint(&this->actor, &targetedActor->focus.pos);
+        this->actor.world.rot.x = pitchTarget - player->actor.shape.rot.x;
+    } else {
+        this->actor.world.rot.x = player->actor.shape.rot.x;
+    }
+
+    this->actor.world.rot.y = player->actor.shape.rot.y; // yaw always like player
+    this->actor.shape.rot.x -= this->actor.world.rot.x; // shape pitch
+    func_8002D9A4(&this->actor, 10.0f); // sets xyz movement speed
+    func_80A9EFE0(this, EnMThunder_Beamblade);
+}
+
+void EnMThunder_Beamblade(EnMThunder* this, GlobalContext* globalCtx) {
     Player* player = GET_PLAYER(globalCtx);
 
-    this->actor.world.pos.x += ((Math_CosS(this->actor.prevPos.x) * - 9.0f) * (Math_SinS(this->actor.shape.rot.y)));
-    this->actor.world.pos.z += ((Math_CosS(this->actor.prevPos.x) * - 9.0f) * (Math_CosS(this->actor.shape.rot.y)));
+    Actor_MoveForward(&this->actor);
 
-    if (Math_StepToF(&this->unk_1AC, 0.0f, 1 / 16.0f)) {
+    if (Math_StepToF(&this->unk_1AC, 0.0f, 1 / 20.0f)) { // sets the duration of the beamblade attack
         Actor_Kill(&this->actor);
     } else {
         Math_SmoothStepToF(&this->actor.scale.x, 20.0f, 1.0f, 2.0f, 0.0f);
-        // (f32* pValue, f32 target, f32 fraction, f32 step, f32 minStep);
+                       // (f32* pValue, f32 target, f32 fraction, f32 step, f32 minStep);
         Actor_SetScale(&this->actor, this->actor.scale.x);
         Collider_UpdateCylinder(&this->actor, &this->collider);
         CollisionCheck_SetAT(globalCtx, &globalCtx->colChkCtx, &this->collider.base);
@@ -378,7 +399,7 @@ void EnMThunder_Draw(Actor* thisx, GlobalContext* globalCtx2) {
     f32 phi_f14;
     s32 phi_t1;
 
-    // Collider_Draw(globalCtx, &this->collider);
+    Collider_Draw(globalCtx, &this->collider);
 
     OPEN_DISPS(globalCtx->state.gfxCtx, "../z_en_m_thunder.c", 844);
     func_80093D84(globalCtx->state.gfxCtx);
@@ -389,7 +410,7 @@ void EnMThunder_Draw(Actor* thisx, GlobalContext* globalCtx2) {
     switch (this->unk_1C6) {
         case 0: // red spin attack
         case 1: // blue spin attack
-        case 2: // bladebeam
+        case 2: // beamblade
             gSPSegment(POLY_XLU_DISP++, 0x08,
                        Gfx_TwoTexScroll(globalCtx->state.gfxCtx, 0, 0xFF - ((u8)(s32)(this->unk_1B4 * 30) & 0xFF), 0,
                                         0x40, 0x20, 1, 0xFF - ((u8)(s32)(this->unk_1B4 * 20) & 0xFF), 0, 8, 8));
@@ -407,11 +428,11 @@ void EnMThunder_Draw(Actor* thisx, GlobalContext* globalCtx2) {
             gSPDisplayList(POLY_XLU_DISP++, gSpinAttack1DL);
             gSPDisplayList(POLY_XLU_DISP++, gSpinAttack2DL);
             break;
-        case 2: // bladebeam
-            if (this->unk_1B8 >= 0.85f) { // red bladebeam
+        case 2: // beamblade
+            if (this->unk_1B8 >= 0.85f) { // red beamblade
                 gDPSetPrimColor(POLY_XLU_DISP++, 0, 0x80, 255, 255, 170, (u8)(this->unk_1B0 * 255));
                 gDPSetEnvColor(POLY_XLU_DISP++, 255, 100, 0, 128);
-            } else { // blue bladebeam
+            } else { // blue beamblade
                 gDPSetPrimColor(POLY_XLU_DISP++, 0, 0x80, 170, 255, 255, (u8)(this->unk_1B0 * 255));
                 gDPSetEnvColor(POLY_XLU_DISP++, 0, 100, 255, 128);
             }

--- a/src/overlays/actors/ovl_En_M_Thunder/z_en_m_thunder.c
+++ b/src/overlays/actors/ovl_En_M_Thunder/z_en_m_thunder.c
@@ -73,8 +73,8 @@ void EnMThunder_Init(Actor* thisx, GlobalContext* globalCtx2) {
                               this->actor.world.pos.z, 255, 255, 255, 0);
     this->lightNode = LightContext_InsertLight(globalCtx, &globalCtx->lightCtx, &this->lightInfo);
     this->collider.dim.radius = 0;
-    this->collider.dim.height = 50;
-    this->collider.dim.yShift = -30;
+    this->collider.dim.height = 40;
+    this->collider.dim.yShift = -20;
     this->unk_1C4 = 8;
     this->unk_1B4 = 0.0f;
     this->actor.world.pos = player->bodyPartsPos[0];
@@ -196,7 +196,7 @@ void func_80A9F408(EnMThunder* this, GlobalContext* globalCtx) {
             if ((this->actor.params & 0xFF00) >> 8) {
                 gSaveContext.unk_13F0 = 1;
             }
-            if (player->doBladebeam == 1) { // player is z-targeting and moving forward, do beamblade
+            if (player->doBeamblade == 1) { // player is z-targeting and moving forward, do beamblade
                 if (player->unk_858 < 0.85f) { // blue beamblade
                     this->collider.info.toucher.dmgFlags = D_80AA044C[this->unk_1C7]; // sets damage flags
                 } else { // red beamblade
@@ -339,6 +339,8 @@ void EnMThunder_SetupBeamblade(EnMThunder* this, GlobalContext* globalCtx) {
     this->actor.world.rot.y = player->actor.shape.rot.y; // yaw always like player
     this->actor.shape.rot.x -= this->actor.world.rot.x; // shape pitch
     func_8002D9A4(&this->actor, 10.0f); // sets xyz movement speed
+    this->collider.dim.height = 50;
+    this->collider.dim.yShift = -25;
     func_80A9EFE0(this, EnMThunder_Beamblade);
 }
 
@@ -437,7 +439,6 @@ void EnMThunder_Draw(Actor* thisx, GlobalContext* globalCtx2) {
                 gDPSetEnvColor(POLY_XLU_DISP++, 0, 100, 255, 128);
             }
             gSPDisplayList(POLY_XLU_DISP++, gUnusedBeamBladeDL);
-            phi_t1 = 0;
             break;
     }
 

--- a/src/overlays/actors/ovl_En_M_Thunder/z_en_m_thunder.c
+++ b/src/overlays/actors/ovl_En_M_Thunder/z_en_m_thunder.c
@@ -399,7 +399,7 @@ void EnMThunder_Draw(Actor* thisx, GlobalContext* globalCtx2) {
     f32 phi_f14;
     s32 phi_t1;
 
-    Collider_Draw(globalCtx, &this->collider);
+    // Collider_Draw(globalCtx, &this->collider);
 
     OPEN_DISPS(globalCtx->state.gfxCtx, "../z_en_m_thunder.c", 844);
     func_80093D84(globalCtx->state.gfxCtx);

--- a/src/overlays/actors/ovl_En_M_Thunder/z_en_m_thunder.c
+++ b/src/overlays/actors/ovl_En_M_Thunder/z_en_m_thunder.c
@@ -53,8 +53,6 @@ static u16 sSfxIds[] = {
     NA_SE_IT_ROLLING_CUT_LV1,
     NA_SE_IT_ROLLING_CUT_LV2,
     NA_SE_IT_ROLLING_CUT_LV1,
-    NA_SE_IT_ROLLING_CUT_LV2,
-    NA_SE_IT_ROLLING_CUT_LV1,
 };
 
 // Setup action

--- a/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/src/overlays/actors/ovl_player_actor/z_player.c
@@ -8207,14 +8207,20 @@ void func_80844AF4(Player* this, GlobalContext* globalCtx) {
 
 s32 func_80844BE4(Player* this, GlobalContext* globalCtx) { // spin attack release animation
     s32 temp;
+    s16 yawDiff;
+
+    yawDiff = this->currentYaw - this->actor.shape.rot.y;
 
     if (func_8083ADD4(globalCtx, this)) {
         this->stateFlags2 |= 0x20000;
     } else {
         if (!CHECK_BTN_ALL(sControlInput->cur.button, BTN_B)) {
-            if (this->stateFlags1 & 0x8000) { // player is z-targeting, do bladebeam
+            // player is z-targeting and moving forwards -> do bladebeam
+            if ((ABS(yawDiff) < 0x1000) && this->actor.speedXZ > 0.1f && (this->stateFlags1 & 0x8000 || CHECK_BTN_ALL(sControlInput->cur.button, BTN_Z))) {
+                this->doBladebeam = 1;
                 temp = D_Bladebeam[Player_HoldsTwoHandedWeapon(this)];
             } else {
+                this->doBladebeam = 0;
                 if ((this->unk_858 >= 0.85f) || func_808375D8(this)) {
                     temp = D_80854384[Player_HoldsTwoHandedWeapon(this)];
                 } else {

--- a/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/src/overlays/actors/ovl_player_actor/z_player.c
@@ -1055,17 +1055,17 @@ static struct_80854190 D_80854190[] = {
     { &gPlayerAnim_002C40, &gPlayerAnim_002C50, &gPlayerAnim_002C48, 3, 10 },
     { &gPlayerAnim_002C70, &gPlayerAnim_002C80, &gPlayerAnim_002C78, 2, 11 },
     { &gPlayerAnim_002B28, &gPlayerAnim_002B30, &gPlayerAnim_002560, 0, 12 },
-    { &gPlayerAnim_002940, &gPlayerAnim_002948, &gPlayerAnim_0024B8, 0, 15 }, // longsword spin attack
-    { &gPlayerAnim_0029C0, &gPlayerAnim_0029C8, &gPlayerAnim_002560, 0, 16 }, // sword spin attack
-    { &gPlayerAnim_0029C0, &gPlayerAnim_0029C8, &gPlayerAnim_0024B8, 0, 16 }, // sword spin attack
+    { &gPlayerAnim_002940, &gPlayerAnim_002948, &gPlayerAnim_0024B8, 0, 15 }, // two-handed spin attack animation set
+    { &gPlayerAnim_0029C0, &gPlayerAnim_0029C8, &gPlayerAnim_002560, 0, 16 }, // one-handed spin attack animation set
+    { &gPlayerAnim_0029C0, &gPlayerAnim_0029C8, &gPlayerAnim_0024B8, 0, 16 }, // one-handed spin attack animation set
 };
 
-static LinkAnimationHeader* D_80854350[] = { // Spin Charge Animation
+static LinkAnimationHeader* D_80854350[] = { // spin charge animations
     &gPlayerAnim_002AE8,
     &gPlayerAnim_002920,
 };
 
-static LinkAnimationHeader* D_80854358[] = { // Spin Charge Animation
+static LinkAnimationHeader* D_80854358[] = { // spin charge animations
     &gPlayerAnim_002AE0,
     &gPlayerAnim_002920,
 };
@@ -1092,7 +1092,7 @@ static LinkAnimationHeader* D_80854378[] = {
 
 static u8 D_80854380[2] = { 0x18, 0x19 };
 static u8 D_80854384[2] = { 0x1A, 0x1B };
-static u8 D_Bladebeam[2] = { 0x0C, 0x0D }; // one and twohanded animation set for bladebeam
+static u8 D_Beamblade[2] = { 0x0C, 0x0D }; // points to one-handed and two-handed animation set for beamblade inside D_80854190
 
 static u16 D_80854388[] = { BTN_B, BTN_CLEFT, BTN_CDOWN, BTN_CRIGHT };
 
@@ -5184,7 +5184,7 @@ void func_8083C50C(Player* this) {
     }
 }
 
-s32 func_8083C544(Player* this, GlobalContext* globalCtx) { // spin attack?
+s32 func_8083C544(Player* this, GlobalContext* globalCtx) {
     if (CHECK_BTN_ALL(sControlInput->cur.button, BTN_B)) {
         if (!(this->stateFlags1 & 0x400000) && (Player_GetSwordHeld(this) != 0) && (this->unk_844 == 1) &&
             (this->heldItemActionParam != PLAYER_AP_STICK)) {
@@ -8215,12 +8215,12 @@ s32 func_80844BE4(Player* this, GlobalContext* globalCtx) { // spin attack relea
         this->stateFlags2 |= 0x20000;
     } else {
         if (!CHECK_BTN_ALL(sControlInput->cur.button, BTN_B)) {
-            // player is z-targeting and moving forwards -> do bladebeam
+            // player is z-targeting and moving forwards -> do beamblade
             if ((ABS(yawDiff) < 0x1000) && this->actor.speedXZ > 0.1f && (this->stateFlags1 & 0x8000 || CHECK_BTN_ALL(sControlInput->cur.button, BTN_Z))) {
-                this->doBladebeam = 1;
-                temp = D_Bladebeam[Player_HoldsTwoHandedWeapon(this)];
+                this->doBeamblade = 1;
+                temp = D_Beamblade[Player_HoldsTwoHandedWeapon(this)];
             } else {
-                this->doBladebeam = 0;
+                this->doBeamblade = 0;
                 if ((this->unk_858 >= 0.85f) || func_808375D8(this)) {
                     temp = D_80854384[Player_HoldsTwoHandedWeapon(this)];
                 } else {

--- a/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/src/overlays/actors/ovl_player_actor/z_player.c
@@ -3620,6 +3620,8 @@ void func_808382BC(Player* this) {
     }
 }
 
+#define DMG_INVIN 40 // 2 seconds
+
 s32 func_808382DC(Player* this, GlobalContext* globalCtx) {
     s32 pad;
     s32 sp68 = false;
@@ -3675,7 +3677,7 @@ s32 func_808382DC(Player* this, GlobalContext* globalCtx) {
             }
 
             this->actor.colChkInfo.damage += this->unk_8A0;
-            func_80837C0C(globalCtx, this, sp5C[this->unk_8A1 - 1], this->unk_8A4, this->unk_8A8, this->unk_8A2, 20);
+            func_80837C0C(globalCtx, this, sp5C[this->unk_8A1 - 1], this->unk_8A4, this->unk_8A8, this->unk_8A2, DMG_INVIN);
         } else {
             sp64 = (this->shieldQuad.base.acFlags & AC_BOUNCED) != 0;
 
@@ -3751,7 +3753,7 @@ s32 func_808382DC(Player* this, GlobalContext* globalCtx) {
                     sp4C = 0;
                 }
 
-                func_80837C0C(globalCtx, this, sp4C, 4.0f, 5.0f, Actor_WorldYawTowardActor(ac, &this->actor), 20);
+                func_80837C0C(globalCtx, this, sp4C, 4.0f, 5.0f, Actor_WorldYawTowardActor(ac, &this->actor), DMG_INVIN);
             } else if (this->invincibilityTimer != 0) {
                 return 0;
             } else {
@@ -3767,7 +3769,7 @@ s32 func_808382DC(Player* this, GlobalContext* globalCtx) {
                      ((this->currentTunic != PLAYER_TUNIC_GORON) || (this->unk_A79 >= D_808544F4[sp48])))) {
                     this->unk_A79 = 0;
                     this->actor.colChkInfo.damage = 4;
-                    func_80837C0C(globalCtx, this, 0, 4.0f, 5.0f, this->actor.shape.rot.y, 20);
+                    func_80837C0C(globalCtx, this, 0, 4.0f, 5.0f, this->actor.shape.rot.y, DMG_INVIN);
                 } else {
                     return 0;
                 }

--- a/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/src/overlays/actors/ovl_player_actor/z_player.c
@@ -1055,17 +1055,17 @@ static struct_80854190 D_80854190[] = {
     { &gPlayerAnim_002C40, &gPlayerAnim_002C50, &gPlayerAnim_002C48, 3, 10 },
     { &gPlayerAnim_002C70, &gPlayerAnim_002C80, &gPlayerAnim_002C78, 2, 11 },
     { &gPlayerAnim_002B28, &gPlayerAnim_002B30, &gPlayerAnim_002560, 0, 12 },
-    { &gPlayerAnim_002940, &gPlayerAnim_002948, &gPlayerAnim_0024B8, 0, 15 },
-    { &gPlayerAnim_0029C0, &gPlayerAnim_0029C8, &gPlayerAnim_002560, 0, 16 },
-    { &gPlayerAnim_0029C0, &gPlayerAnim_0029C8, &gPlayerAnim_0024B8, 0, 16 },
+    { &gPlayerAnim_002940, &gPlayerAnim_002948, &gPlayerAnim_0024B8, 0, 15 }, // longsword spin attack
+    { &gPlayerAnim_0029C0, &gPlayerAnim_0029C8, &gPlayerAnim_002560, 0, 16 }, // sword spin attack
+    { &gPlayerAnim_0029C0, &gPlayerAnim_0029C8, &gPlayerAnim_0024B8, 0, 16 }, // sword spin attack
 };
 
-static LinkAnimationHeader* D_80854350[] = {
+static LinkAnimationHeader* D_80854350[] = { // Spin Charge Animation
     &gPlayerAnim_002AE8,
     &gPlayerAnim_002920,
 };
 
-static LinkAnimationHeader* D_80854358[] = {
+static LinkAnimationHeader* D_80854358[] = { // Spin Charge Animation
     &gPlayerAnim_002AE0,
     &gPlayerAnim_002920,
 };
@@ -1092,6 +1092,7 @@ static LinkAnimationHeader* D_80854378[] = {
 
 static u8 D_80854380[2] = { 0x18, 0x19 };
 static u8 D_80854384[2] = { 0x1A, 0x1B };
+static u8 D_Bladebeam[2] = { 0x0C, 0x0D }; // one and twohanded animation set for bladebeam
 
 static u16 D_80854388[] = { BTN_B, BTN_CLEFT, BTN_CDOWN, BTN_CRIGHT };
 
@@ -3194,7 +3195,7 @@ s32 func_808374A0(GlobalContext* globalCtx, Player* this, SkelAnime* skelAnime, 
     return -1;
 }
 
-void func_80837530(GlobalContext* globalCtx, Player* this, s32 arg2) {
+void func_80837530(GlobalContext* globalCtx, Player* this, s32 arg2) { // spawn spin attack actor
     if (arg2 != 0) {
         this->unk_858 = 0.0f;
     } else {
@@ -3246,13 +3247,13 @@ s32 func_808375D8(Player* this) {
     return 1;
 }
 
-void func_80837704(GlobalContext* globalCtx, Player* this) {
+void func_80837704(GlobalContext* globalCtx, Player* this) { // spin attack charge
     LinkAnimationHeader* anim;
 
     if ((this->swordAnimation >= 4) && (this->swordAnimation < 8)) {
-        anim = D_80854358[Player_HoldsTwoHandedWeapon(this)];
+        anim = D_80854358[Player_HoldsTwoHandedWeapon(this)]; // spin attack charging animation
     } else {
-        anim = D_80854350[Player_HoldsTwoHandedWeapon(this)];
+        anim = D_80854350[Player_HoldsTwoHandedWeapon(this)]; // spin attack charging animation
     }
 
     func_80832318(this);
@@ -5183,7 +5184,7 @@ void func_8083C50C(Player* this) {
     }
 }
 
-s32 func_8083C544(Player* this, GlobalContext* globalCtx) {
+s32 func_8083C544(Player* this, GlobalContext* globalCtx) { // spin attack?
     if (CHECK_BTN_ALL(sControlInput->cur.button, BTN_B)) {
         if (!(this->stateFlags1 & 0x400000) && (Player_GetSwordHeld(this) != 0) && (this->unk_844 == 1) &&
             (this->heldItemActionParam != PLAYER_AP_STICK)) {
@@ -8204,17 +8205,21 @@ void func_80844AF4(Player* this, GlobalContext* globalCtx) {
     }
 }
 
-s32 func_80844BE4(Player* this, GlobalContext* globalCtx) {
+s32 func_80844BE4(Player* this, GlobalContext* globalCtx) { // spin attack release animation
     s32 temp;
 
     if (func_8083ADD4(globalCtx, this)) {
         this->stateFlags2 |= 0x20000;
     } else {
         if (!CHECK_BTN_ALL(sControlInput->cur.button, BTN_B)) {
-            if ((this->unk_858 >= 0.85f) || func_808375D8(this)) {
-                temp = D_80854384[Player_HoldsTwoHandedWeapon(this)];
+            if (this->stateFlags1 & 0x8000) { // player is z-targeting, do bladebeam
+                temp = D_Bladebeam[Player_HoldsTwoHandedWeapon(this)];
             } else {
-                temp = D_80854380[Player_HoldsTwoHandedWeapon(this)];
+                if ((this->unk_858 >= 0.85f) || func_808375D8(this)) {
+                    temp = D_80854384[Player_HoldsTwoHandedWeapon(this)];
+                } else {
+                    temp = D_80854380[Player_HoldsTwoHandedWeapon(this)];
+                }                
             }
 
             func_80837948(globalCtx, this, temp);

--- a/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/src/overlays/actors/ovl_player_actor/z_player.c
@@ -10457,8 +10457,12 @@ void Player_Draw(Actor* thisx, GlobalContext* globalCtx2) {
         func_80093C80(globalCtx);
         func_80093D84(globalCtx->state.gfxCtx);
 
+        /* if (this->invincibilityTimer > 0) {
+            this->unk_88F += CLAMP(50 - this->invincibilityTimer, 8, 40);
+            POLY_OPA_DISP =
+                Gfx_SetFog2(POLY_OPA_DISP, 255, 0, 0, 0, 0, 4000 - (s32)(Math_CosS(this->unk_88F * 256) * 2000.0f)); */
+        // changed to Link's damage flash from April 1998
         if ((this->invincibilityTimer > 0) && (this->invincibilityTimer % 2) == 0) {
-            // Link's damage flash from April 1998
             POLY_OPA_DISP = Gfx_SetFog2(POLY_OPA_DISP, 155, 155, 20, 0, 0, 500);
         }
 


### PR DESCRIPTION
- standalone shield from Spaceworld
- allow first person view while Link carries items
- pull items without immediately using them
- damage flash from April 1998
- put away sword and shield items during running
- rolling completely removed
- manual jumping added
- beamblade added to en_m_thunder
- cylinder draw functions added for debugging